### PR TITLE
correct cookbook name from 'graphite' to 'graphiti' in recipe headers

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: graphite
+# Cookbook Name:: graphiti
 # Recipe:: default
 #
 # Copyright 2012, AJ Christensen <aj@junglist.gen.nz>

--- a/recipes/firewall.rb
+++ b/recipes/firewall.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: graphite
+# Cookbook Name:: graphiti
 # Recipe:: firewall
 #
 # Copyright 2012, AJ Christensen <aj@junglist.gen.nz>

--- a/recipes/graph_generator.rb
+++ b/recipes/graph_generator.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: graphite
+# Cookbook Name:: graphiti
 # Recipe:: graph_generator
 #
 # Copyright 2012, AJ Christensen <aj@junglist.gen.nz>


### PR DESCRIPTION
I missed this in my prior commit -- I updated my patch but you'd already merged! Awesome speed!
